### PR TITLE
Fix types declarations in  package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	"author": "Timotej Valentin Rojko",
 	"exports": {
 		"require": "./index.js",
-		"import": "./index.mjs"
+		"import": "./index.mjs",
+		"types": "./index.d.ts"
 	},
 	"main": "index.js",
 	"types": "./index.d.ts",


### PR DESCRIPTION
Hey! I noticed that when imported from "sweph" I'm getting type issue for not being able to find types. This should fix it

```
import * as swe from "sweph";

// error below
Could not find a declaration file for module 'sweph'. '/Users/...../node_modules/sweph/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/...../node_modules/sweph/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'sweph' library may need to update its package.json or typings.ts (7016)
```