### PR TITLE
feat: add deg_midp binding for swe_deg_midp

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2333,6 +2333,26 @@ declare module "sweph" {
 
 	/**
 	 * ### Description
+	 * Midpoint between two points in degrees
+	 * ### Params
+	 * ```
+	 * • deg1: number // First point in degrees
+	 * • deg2: number // Second point in degrees
+	 * ```
+	 * ### Returns
+	 * ```
+	 * number // Midpoint in degrees
+	 * ```
+	 * ### Example
+	 * ```
+	 * const mid = deg_midp(10, 350); // 0
+	 * ```
+	 * &nbsp;
+	 */
+	export function deg_midp(deg1: number, deg2: number): number;
+
+	/**
+	 * ### Description
 	 * Arc distance between two points in degrees in a single direction
 	 * ### Params
 	 * ```

--- a/index.mjs
+++ b/index.mjs
@@ -100,6 +100,7 @@ export const difcsn = s.difcsn;
 export const difdegn = s.difdegn;
 export const difcs2n = s.difcs2n;
 export const difdeg2n = s.difdeg2n;
+export const deg_midp = s.deg_midp;
 export const csroundsec = s.csroundsec;
 export const d2l = s.d2l;
 export const day_of_week = s.day_of_week;

--- a/src/functions/deg_midp.cpp
+++ b/src/functions/deg_midp.cpp
@@ -1,0 +1,19 @@
+#include <sweph.h>
+
+constexpr std::pair<int, const char*> args[] = {
+	{ 2, "Expecting 2 arguments: deg1, deg2" },
+	{ NUMBER, "Argument 1 should be a number - first point in degrees" },
+	{ NUMBER, "Argument 2 should be a number - second point in degrees" }
+};
+
+Napi::Value sweph_deg_midp(const Napi::CallbackInfo& info) {
+	Napi::Env env = info.Env();
+	if(!sweph_type_check(args, info)) {
+		return env.Null();
+	}
+	double mid = swe_deg_midp(
+		info[0].As<Napi::Number>().DoubleValue(),
+		info[1].As<Napi::Number>().DoubleValue()
+	);
+	return Napi::Number::New(env, mid);
+}

--- a/src/sweph.cpp
+++ b/src/sweph.cpp
@@ -84,6 +84,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 	exports["difdegn"] = Napi::Function::New(env, sweph_difdegn);
 	exports["difcs2n"] = Napi::Function::New(env, sweph_difcs2n);
 	exports["difdeg2n"] = Napi::Function::New(env, sweph_difdeg2n);
+	exports["deg_midp"] = Napi::Function::New(env, sweph_deg_midp);
 	exports["csroundsec"] = Napi::Function::New(env, sweph_csroundsec);
 	exports["d2l"] = Napi::Function::New(env, sweph_d2l);
 	exports["day_of_week"] = Napi::Function::New(env, sweph_day_of_week);

--- a/src/sweph.h
+++ b/src/sweph.h
@@ -88,6 +88,7 @@ Napi::Value sweph_difcsn(const Napi::CallbackInfo& info);
 Napi::Value sweph_difcs2n(const Napi::CallbackInfo& info);
 Napi::Value sweph_difdegn(const Napi::CallbackInfo& info);
 Napi::Value sweph_difdeg2n(const Napi::CallbackInfo& info);
+Napi::Value sweph_deg_midp(const Napi::CallbackInfo& info);
 Napi::Value sweph_csroundsec(const Napi::CallbackInfo& info);
 Napi::Value sweph_d2l(const Napi::CallbackInfo& info);
 Napi::Value sweph_day_of_week(const Napi::CallbackInfo& info);


### PR DESCRIPTION
## Summary

- Wraps `swe_deg_midp(x1, x0)` from the Swiss Ephemeris C API, which computes the arc midpoint between two angles in degrees taking the shortest path around the circle
- Adds the N-API binding (`src/functions/deg_midp.cpp`), declaration in `src/sweph.h`, registration in `src/sweph.cpp`, ESM export in `index.mjs`, and TypeScript type in `index.d.ts`

**Context:** `deg_midp` was the only missing member of the degree utility family — `degnorm`, `difdegn`, `difdeg2n`, and `csroundsec` were all already exposed, but the midpoint function was not. This closes that gap.

## Test plan

- [ ] `npm install --build-from-source` compiles without errors
- [ ] `deg_midp(10, 350)` returns `0` (midpoint wrapping through 0°)
- [ ] `deg_midp(90, 180)` returns `135`
- [ ] Passing a non-number throws a `TypeError` with a descriptive message
- [ ] Type appears in editor autocomplete via `index.d.ts`